### PR TITLE
Add PrimaryServiceConfigId property

### DIFF
--- a/Source/Microsoft.Xbox.Services.Test.CSharp/XboxLiveAppConfiguration.cs
+++ b/Source/Microsoft.Xbox.Services.Test.CSharp/XboxLiveAppConfiguration.cs
@@ -1,20 +1,15 @@
 // Copyright (c) Microsoft Corporation
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-// 
+
 namespace Microsoft.Xbox.Services
 {
-    using global::System;
-    using global::System.IO;
-
-    using Newtonsoft.Json;
-
     public partial class XboxLiveAppConfiguration
     {
         public static XboxLiveAppConfiguration Load(string path)
         {
             return new XboxLiveAppConfiguration
             {
-                ServiceConfigurationId = "00000000-0000-0000-0000-0000694f5acb",
+                PrimaryServiceConfigId = "00000000-0000-0000-0000-0000694f5acb",
                 TitleId = 1766808267,
                 Environment = string.Empty,
                 Sandbox = "JDTDWX.0",

--- a/Source/api/Leaderboard/LeaderboardService.cs
+++ b/Source/api/Leaderboard/LeaderboardService.cs
@@ -35,11 +35,11 @@ namespace Microsoft.Xbox.Services.Leaderboard
             string requestPath;
             if (string.IsNullOrEmpty(query.SocialGroup))
             {
-                requestPath = CreateLeaderboardUrlPath(this.appConfig.ServiceConfigurationId, query.StatName, query.MaxItems, skipToXboxUserId, query.SkipResultsToRank, query.ContinuationToken);
+                requestPath = CreateLeaderboardUrlPath(this.appConfig.PrimaryServiceConfigId, query.StatName, query.MaxItems, skipToXboxUserId, query.SkipResultsToRank, query.ContinuationToken);
             }
             else
             {
-                requestPath = CreateSocialLeaderboardUrlPath(this.appConfig.ServiceConfigurationId, query.StatName, user.XboxUserId, query.MaxItems, skipToXboxUserId, query.SkipResultsToRank, query.ContinuationToken, query.SocialGroup);
+                requestPath = CreateSocialLeaderboardUrlPath(this.appConfig.PrimaryServiceConfigId, query.StatName, user.XboxUserId, query.MaxItems, skipToXboxUserId, query.SkipResultsToRank, query.ContinuationToken, query.SocialGroup);
             }
 
             XboxLiveHttpRequest request = XboxLiveHttpRequest.Create(this.xboxLiveContextSettings, HttpMethod.Get, leaderboardsBaseUri.ToString(), requestPath);

--- a/Source/api/Stats/Manager/StatsService.cs
+++ b/Source/api/Stats/Manager/StatsService.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Xbox.Services.Stats.Manager
         {
             string pathAndQuery = PathAndQueryStatSubpath(
                 user.XboxUserId,
-                this.config.ServiceConfigurationId,
+                this.config.PrimaryServiceConfigId,
                 false
             );
 
@@ -64,7 +64,7 @@ namespace Microsoft.Xbox.Services.Stats.Manager
         {
             string pathAndQuery = PathAndQueryStatSubpath(
                 user.XboxUserId,
-                this.config.ServiceConfigurationId,
+                this.config.PrimaryServiceConfigId,
                 false
             );
 

--- a/Source/api/XboxLiveAppConfiguration.cs
+++ b/Source/api/XboxLiveAppConfiguration.cs
@@ -41,8 +41,7 @@ namespace Microsoft.Xbox.Services
 
         internal bool UseFirstPartyToken { get; set; }
 
-        [JsonProperty("PrimaryServiceConfigId")]
-        public string ServiceConfigurationId { get; set; }
+        public string PrimaryServiceConfigId { get; set; }
 
         public uint TitleId { get; set; }
 

--- a/Source/api/XboxLiveAppConfiguration.cs
+++ b/Source/api/XboxLiveAppConfiguration.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-// 
 
 namespace Microsoft.Xbox.Services
 {
@@ -40,7 +39,21 @@ namespace Microsoft.Xbox.Services
 
         internal bool UseFirstPartyToken { get; set; }
 
-        public string ServiceConfigurationId { get; set; }
+        public string PrimaryServiceConfigId { get; set; }
+
+        [Obsolete("Use PrimaryServiceConfigId instead")]
+        public string ServiceConfigurationId
+        {
+            get
+            {
+                return this.PrimaryServiceConfigId;
+            }
+
+            set
+            {
+                this.PrimaryServiceConfigId = value;
+            }
+        }
 
         public uint TitleId { get; set; }
 
@@ -72,7 +85,5 @@ namespace Microsoft.Xbox.Services
                 throw new XboxException(string.Format("Unable to find or load Xbox Live configuration.  Make sure a properly configured {0} exists.", FileName), e);
             }
         }
-
-
     }
 }

--- a/Source/api/XboxLiveAppConfiguration.cs
+++ b/Source/api/XboxLiveAppConfiguration.cs
@@ -5,6 +5,8 @@ namespace Microsoft.Xbox.Services
 {
     using global::System;
 
+    using Newtonsoft.Json;
+
     public partial class XboxLiveAppConfiguration
     {
         public const string FileName = "XboxServices.config";
@@ -39,21 +41,8 @@ namespace Microsoft.Xbox.Services
 
         internal bool UseFirstPartyToken { get; set; }
 
-        public string PrimaryServiceConfigId { get; set; }
-
-        [Obsolete("Use PrimaryServiceConfigId instead")]
-        public string ServiceConfigurationId
-        {
-            get
-            {
-                return this.PrimaryServiceConfigId;
-            }
-
-            set
-            {
-                this.PrimaryServiceConfigId = value;
-            }
-        }
+        [JsonProperty("PrimaryServiceConfigId")]
+        public string ServiceConfigurationId { get; set; }
 
         public uint TitleId { get; set; }
 


### PR DESCRIPTION
Updated all uses to use PrimaryServiceConfigId instead of ServiceConfigurationId.
Marked ServiceConfigurationId as obsolete and redirect all property accesses to the new value.