### PR TITLE
Fix 'Invalid config file' due to XboxLiveCreatorsTitle property

### DIFF
--- a/Source/api/Common/XboxLiveAppConfiguration.cs
+++ b/Source/api/Common/XboxLiveAppConfiguration.cs
@@ -60,6 +60,8 @@ namespace Microsoft.Xbox.Services
 
         public string Environment { get; set; }
 
+        public bool XboxLiveCreatorsTitle { get; set; }
+
         public string GetEndpointForService(string serviceName, string protocol = "https")
         {
             return string.Format("{0}://{1}{2}.xboxlive.com", protocol, serviceName, string.IsNullOrEmpty(this.Environment) ? string.Empty : ("." + this.Environment));


### PR DESCRIPTION
Update XboxLiveAppConfiguration to include XboxLiveCreatorsTitle